### PR TITLE
Build: Fix build done by gecko

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,8 +10,9 @@ SRC_DIR="$(dirname "${BASH_SOURCE[0]}")"
 source "${SRC_DIR}/env.sh"
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    go get -u -d "github.com/$SALTICIDAE_ORG/salticidae-go"
+    go get -d "github.com/$SALTICIDAE_ORG/salticidae-go"
     cd "$SALTICIDAE_GO_PATH"
+    git fetch
     git checkout "$SALTICIDAE_GO_VER"
     git submodule update --init --recursive
     cd "$SALTICIDAE_PATH"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,8 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 PREFIX="${PREFIX:-$(pwd)/build}"
 SRC_DIR="$(dirname "${BASH_SOURCE[0]}")"

--- a/setup.sh
+++ b/setup.sh
@@ -6,8 +6,8 @@ set -o pipefail
 
 tmpdir=$(mktemp -d -t salticidae-go-XXXXXXXX)
 cd "$tmpdir"
-curl -s https://raw.githubusercontent.com/ava-labs/salticidae-go/master/scripts/build.sh -o ./build.sh
-curl -s https://raw.githubusercontent.com/ava-labs/salticidae-go/master/scripts/env.sh -o ./env.sh
+curl -sS https://raw.githubusercontent.com/ava-labs/salticidae-go/master/scripts/build.sh -o ./build.sh
+curl -sS https://raw.githubusercontent.com/ava-labs/salticidae-go/master/scripts/env.sh -o ./env.sh
 chmod +x ./build.sh
 source ./env.sh
 ./build.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,9 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
 tmpdir=$(mktemp -d -t salticidae-go-XXXXXXXX)
 cd "$tmpdir"
 curl -s https://raw.githubusercontent.com/ava-labs/salticidae-go/master/scripts/build.sh -o ./build.sh


### PR DESCRIPTION
I found that gecko was unable to build salticidae-go, because 
1. running https://github.com/ava-labs/gecko/blob/master/scripts/build.sh
2. sources https://github.com/ava-labs/gecko/blob/master/scripts/env.sh
3. which downloads and executes https://raw.githubusercontent.com/ava-labs/salticidae-go/v0.1.0/setup.sh
4. which cause a *tag* to be checked out in $GOPATH/src/github.com/ava-labs/salticidae-go
5. which causes an error when `scripts/build.sh` does an implicit git pull by running `go get -u ...`

This excerpt from a `set o trace` run of `scripts/build.sh` shows the error
 ```
++ CGO_CFLAGS=-I/root/go/src/github.com/ava-labs/salticidae-go/salticidae/build/include/
++ export 'CGO_LDFLAGS=-L/root/go/src/github.com/ava-labs/salticidae-go/salticidae/build/lib/ -lsalticidae -luv -lssl -lcrypto -lstdc++'
++ CGO_LDFLAGS='-L/root/go/src/github.com/ava-labs/salticidae-go/salticidae/build/lib/ -lsalticidae -luv -lssl -lcrypto -lstdc++'
+ [[ linux-gnu == \l\i\n\u\x\-\g\n\u ]]
+ go get -u -d github.com/ava-labs/salticidae-go
# cd /root/go/src/github.com/ava-labs/salticidae-go; git pull --ff-only
You are not currently on a branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

package github.com/ava-labs/salticidae-go: exit status 1
```

This will need an accompanying tag and change to `SALTICIDAE_GO_VER`.